### PR TITLE
Fix option parsing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,14 +7,13 @@ cache:
   - '%LOCALAPPDATA%\Mozilla\sccache'
 build_script:
   - bash ./tools/import-upstream.sh
-  - cd src
-  - bash ./get-clang.sh
+  - bash -c 'cd src; ./get-clang.sh'
   - bash -c '~/.cargo/bin/sccache -s'
-  - bash ./build.sh
+  - bash -c 'cd src; ./build.sh'
   - bash -c '~/.cargo/bin/sccache -s'
   - bash -c 'mkdir naive-$APPVEYOR_REPO_TAG_NAME-win64'
-  - bash -c 'cp out/Release/naive.exe config.json LICENSE naive-$APPVEYOR_REPO_TAG_NAME-win64/'
-  - bash -c '7z a ../naive-$APPVEYOR_REPO_TAG_NAME-win64.zip naive-$APPVEYOR_REPO_TAG_NAME-win64/'
+  - bash -c 'cp src/out/Release/naive.exe src/config.json LICENSE naive-$APPVEYOR_REPO_TAG_NAME-win64/'
+  - bash -c '7z a naive-$APPVEYOR_REPO_TAG_NAME-win64.zip naive-$APPVEYOR_REPO_TAG_NAME-win64/'
 test: off
 artifacts:
   - path: naive-$(APPVEYOR_REPO_TAG_NAME)-win64.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,12 @@ addons:
 cache: ccache
 script:
   - ./tools/import-upstream.sh
-  - cd src
-  - ./get-clang.sh
+  - ( cd src; ./get-clang.sh )
   - ccache -s
-  - ./build.sh
+  - ( cd src; ./build.sh )
   - mkdir naiveproxy-$TRAVIS_BRANCH-$TRAVIS_OS_NAME
-  - cp out/Release/naive config.json LICENSE naiveproxy-$TRAVIS_BRANCH-$TRAVIS_OS_NAME/
-  - tar cJf ../naiveproxy-$TRAVIS_BRANCH-$TRAVIS_OS_NAME.tar.xz naiveproxy-$TRAVIS_BRANCH-$TRAVIS_OS_NAME/
+  - cp src/out/Release/naive src/config.json LICENSE naiveproxy-$TRAVIS_BRANCH-$TRAVIS_OS_NAME/
+  - tar cJf naiveproxy-$TRAVIS_BRANCH-$TRAVIS_OS_NAME.tar.xz naiveproxy-$TRAVIS_BRANCH-$TRAVIS_OS_NAME/
 deploy:
   provider: releases
   api_key:

--- a/src/get-clang.sh
+++ b/src/get-clang.sh
@@ -19,14 +19,14 @@ case "$ARCH" in
 esac
 if [ ! -d third_party/llvm-build/Release+Asserts/bin ]; then
   mkdir -p third_party/llvm-build/Release+Asserts
-  curl "$clang_url" -o- | tar xzf - -C third_party/llvm-build/Release+Asserts
+  curl "$clang_url" | tar xzf - -C third_party/llvm-build/Release+Asserts
 fi
 
 # AFDO profile (Linux)
 if [ "$ARCH" = Linux -a ! -f chrome/android/profiles/afdo.prof ]; then
   AFDO_PATH=$(cat chrome/android/profiles/newest.txt)
   afdo_url="https://storage.googleapis.com/chromeos-prebuilt/afdo-job/llvm/$AFDO_PATH"
-  curl "$afdo_url" -o- | bzip2 -cd >chrome/android/profiles/afdo.prof
+  curl "$afdo_url" | bzip2 -cd >chrome/android/profiles/afdo.prof
 fi
 
 # sccache (Windows)
@@ -43,25 +43,12 @@ fi
 
 # gn
 if [ ! -f gn/out/gn ]; then
-  if [ "$CI" -o "$ARCH" = Windows ]; then
-    mkdir -p gn/out
-    cd gn/out
-    case "$ARCH" in
-      Linux) curl -L https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/latest -o gn.zip;;
-      Darwin) curl -L https://chrome-infra-packages.appspot.com/dl/gn/gn/mac-amd64/+/latest -o gn.zip;;
-      Windows) curl -L https://chrome-infra-packages.appspot.com/dl/gn/gn/windows-amd64/+/latest -o gn.zip;;
-    esac
-    unzip gn.zip
-  else
-    rm -rf gn
-    git clone --single-branch https://gn.googlesource.com/gn
-    export PATH="$PWD/third_party/llvm-build/Release+Asserts/bin:$PATH"
-    cd gn
-    if which ccache >/dev/null 2>&1; then
-      export CC='ccache clang' CXX='ccache clang++' CCACHE_BASEDIR="$PWD"
-    fi
-    python2=$(which python2 2>/dev/null || which python 2>/dev/null)
-    $python2 build/gen.py
-    ninja -C out gn
-  fi
+  mkdir -p gn/out
+  cd gn/out
+  case "$ARCH" in
+    Linux) curl -L https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/latest -o gn.zip;;
+    Darwin) curl -L https://chrome-infra-packages.appspot.com/dl/gn/gn/mac-amd64/+/latest -o gn.zip;;
+    Windows) curl -L https://chrome-infra-packages.appspot.com/dl/gn/gn/windows-amd64/+/latest -o gn.zip;;
+  esac
+  unzip gn.zip
 fi

--- a/src/net/tools/naive/naive_proxy_bin.cc
+++ b/src/net/tools/naive/naive_proxy_bin.cc
@@ -275,10 +275,6 @@ bool ParseCommandLine(const CommandLine& cmdline, Params* params) {
       std::cerr << "Invalid proxy URL" << std::endl;
       return false;
     }
-    if (url.scheme() != "https" && url.scheme() != "quic") {
-      std::cerr << "Must be HTTPS or QUIC proxy" << std::endl;
-      return false;
-    }
     params->proxy_url = url::SchemeHostPort(url).Serialize();
     params->proxy_user = url.username();
     params->proxy_pass = url.password();

--- a/src/net/tools/naive/naive_proxy_bin.cc
+++ b/src/net/tools/naive/naive_proxy_bin.cc
@@ -188,20 +188,23 @@ void GetCommandLine(const base::CommandLine& proc, CommandLine* cmdline) {
   cmdline->listen = proc.GetSwitchValueASCII("listen");
   cmdline->proxy = proc.GetSwitchValueASCII("proxy");
   cmdline->padding = proc.HasSwitch("padding");
-  cmdline->host_resolver_rules = proc.GetSwitchValueASCII("host-resolver-rules");
+  cmdline->host_resolver_rules =
+      proc.GetSwitchValueASCII("host-resolver-rules");
   cmdline->no_log = !proc.HasSwitch("log");
   cmdline->log = proc.GetSwitchValuePath("log");
   cmdline->log_net_log = proc.GetSwitchValuePath("log-net-log");
   cmdline->ssl_key_log_file = proc.GetSwitchValuePath("ssl-key-log-file");
 }
 
-void GetCommandLineFromConfig(const base::FilePath& config_path, CommandLine* cmdline) {
+void GetCommandLineFromConfig(const base::FilePath& config_path,
+                              CommandLine* cmdline) {
   JSONFileValueDeserializer reader(config_path);
   int error_code;
   std::string error_message;
   auto value = reader.Deserialize(&error_code, &error_message);
   if (value == nullptr) {
-    std::cerr << "Error reading " << config_path << ": (" << error_code << ") " << error_message << std::endl;
+    std::cerr << "Error reading " << config_path << ": (" << error_code << ") "
+              << error_message << std::endl;
     exit(EXIT_FAILURE);
   }
   if (!value->is_dict()) {
@@ -219,24 +222,29 @@ void GetCommandLineFromConfig(const base::FilePath& config_path, CommandLine* cm
     cmdline->padding = value->FindKey("padding")->GetBool();
   }
   if (value->FindKeyOfType("host-resolver-rules", base::Value::Type::STRING)) {
-    cmdline->host_resolver_rules = value->FindKey("host-resolver-rules")->GetString();
+    cmdline->host_resolver_rules =
+        value->FindKey("host-resolver-rules")->GetString();
   }
   cmdline->no_log = true;
   if (value->FindKeyOfType("log", base::Value::Type::STRING)) {
     cmdline->no_log = false;
-    cmdline->log = base::FilePath::FromUTF8Unsafe(value->FindKey("log")->GetString());
+    cmdline->log =
+        base::FilePath::FromUTF8Unsafe(value->FindKey("log")->GetString());
   }
   if (value->FindKeyOfType("log-net-log", base::Value::Type::STRING)) {
-    cmdline->log_net_log = base::FilePath::FromUTF8Unsafe(value->FindKey("log-net-log")->GetString());
+    cmdline->log_net_log = base::FilePath::FromUTF8Unsafe(
+        value->FindKey("log-net-log")->GetString());
   }
   if (value->FindKeyOfType("ssl-key-log-file", base::Value::Type::STRING)) {
-    cmdline->ssl_key_log_file = base::FilePath::FromUTF8Unsafe(value->FindKey("ssl-key-log-file")->GetString());
+    cmdline->ssl_key_log_file = base::FilePath::FromUTF8Unsafe(
+        value->FindKey("ssl-key-log-file")->GetString());
   }
 }
 
 std::string GetProxyFromURL(const GURL& url) {
   auto shp = url::SchemeHostPort(url);
-  if (url::DefaultPortForScheme(shp.scheme().c_str(), shp.scheme().size()) == url::PORT_UNSPECIFIED) {
+  if (url::DefaultPortForScheme(shp.scheme().c_str(), shp.scheme().size()) ==
+      url::PORT_UNSPECIFIED) {
     return shp.Serialize() + ":" + base::IntToString(shp.port());
   } else {
     return shp.Serialize();
@@ -304,7 +312,8 @@ bool ParseCommandLine(const CommandLine& cmdline, Params* params) {
     if (url.HostIsIPAddress()) {
       GURL::Replacements set_host;
       set_host.SetHostStr(kDefaultHostName);
-      params->proxy_url = GetProxyFromURL(url_no_auth.ReplaceComponents(set_host));
+      params->proxy_url =
+          GetProxyFromURL(url_no_auth.ReplaceComponents(set_host));
       LOG(INFO) << "Using '" << kDefaultHostName << "' as the hostname for "
                 << url.host();
       params->host_resolver_rules =
@@ -454,7 +463,8 @@ int main(int argc, char* argv[]) {
     LOG(ERROR) << "Failed to listen: " << result;
     return EXIT_FAILURE;
   }
-  LOG(INFO) << "Listening on " << params.listen_addr << ":" << params.listen_port;
+  LOG(INFO) << "Listening on " << params.listen_addr << ":"
+            << params.listen_port;
 
   net::NaiveProxy naive_proxy(std::move(listen_socket), params.protocol,
                               params.use_padding, session, kTrafficAnnotation);


### PR DESCRIPTION
Fix parsing of socks://ip:port, which got parsed to socks://ip.

Also, path cleanup in CI configs. Use prebuilt gn binaries for all platforms, which failed to build on MacOS for unclear reason.