### PR TITLE
quic: Fix HTTP/3 Fast CONNECT behavior

### DIFF
--- a/src/net/quic/quic_proxy_client_socket.cc
+++ b/src/net/quic/quic_proxy_client_socket.cc
@@ -316,16 +316,12 @@ int QuicProxyClientSocket::DoLoop(int last_io_result) {
         if (use_fastopen_ && read_headers_pending_) {
           read_headers_pending_ = false;
           if (rv < 0) {
-            // read_callback_ cannot be called.
-            if (!read_callback_)
-              rv = ERR_IO_PENDING;
             // read_callback_ will be called with this error and be reset.
             // Further data after that will be ignored.
             next_state_ = STATE_DISCONNECTED;
-          } else {
-            // Does not call read_callback_ from here if headers are OK.
-            rv = ERR_IO_PENDING;
           }
+          // Prevents calling connect_callback_.
+          rv = ERR_IO_PENDING;
         }
         break;
       default:


### PR DESCRIPTION
SpdyProxyClientSocket uses read_callback_ for both Connect(), and
Read() and its OnIOComplete() calls read_callback_, thus its fast
connect code checks read_callback_. The code was ported to
QuicProxyClientSocket without much change.

But QuicProxyClientSocket uses a separate connect_callback_ apart from
read_callback_, and its OnIOComplete() calls connect_callback_, thus
when headers are received after Connect() it doesn't need to check
read_callback_ and should always avoid calling connect_callback_.