### PR TITLE
Fix x86 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - name: "linux-arm"
       os: linux
       dist: bionic
-      env: EXTRA_FLAGS='target_cpu="arm" target_sysroot="'"$TRAVIS_BUILD_DIR"'/src/build/linux/debian_sid_arm-sysroot"'
+      env: EXTRA_FLAGS='target_cpu="arm" use_sysroot=false target_sysroot="'"$TRAVIS_BUILD_DIR"'/src/build/linux/debian_sid_arm-sysroot"'
     - name: "osx"
       os: osx
       osx_image: xcode10.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - name: "linux-arm"
       os: linux
       dist: bionic
-      env: EXTRA_FLAGS='target_cpu="arm"'
+      env: EXTRA_FLAGS='target_cpu="arm" target_sysroot="'"$TRAVIS_BUILD_DIR"'/src/build/linux/debian_sid_arm-sysroot"'
     - name: "osx"
       os: osx
       osx_image: xcode10.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
     - name: "linux-x64"
       os: linux
       dist: bionic
+    - name: "linux-x86"
+      os: linux
+      dist: bionic
+      env: EXTRA_FLAGS='target_cpu="x86"'
     - name: "linux-arm64"
       os: linux
       dist: bionic

--- a/src/get-clang.sh
+++ b/src/get-clang.sh
@@ -23,8 +23,10 @@ if [ "$ARCH" = Linux ]; then
     arm64)
       build_sysroot ARM64
     ;;
-    arm)
+    x86)
       build_sysroot I386
+    ;;
+    arm)
       build_sysroot ARM
     ;;
   esac

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -6,6 +6,7 @@ eval "$EXTRA_FLAGS"
 if [ "$(uname)" = Linux ]; then
   case "$target_cpu" in
     arm64) naive="qemu-aarch64 -L src/build/linux/debian_sid_arm64-sysroot $naive";;
+    x86) naive="qemu-i386 -L src/build/linux/debian_sid_i386-sysroot $naive";;
     arm) naive="qemu-arm -L src/build/linux/debian_sid_arm-sysroot $naive";;
   esac
 fi


### PR DESCRIPTION
I spot a missing case for x86 build and this is a quick fix.

Btw do you mind adding x86 binary release? IMO many old IBM ThinkPads are perfect for DIY home router running naiveproxy (i'm running it on a ThinkPad X60). It would save people time to do the (cross) compiling.