### PR TITLE
Remove the naked IP logic description in document usage

### DIFF
--- a/USAGE.txt
+++ b/USAGE.txt
@@ -49,9 +49,7 @@ Options:
 
         Routes traffic via the proxy server. Allowed values for proto:
         "https", "quic". The value of port is inferred from proto if not
-        specified. If hostname is an IP address, an internal host
-        resolver rule is setup to resolve "example" to it to make TLS
-        certificate validation work.
+        specified.
 
         If this option is not set, connects to origin server directly.
 


### PR DESCRIPTION
USAGE.txt 有关于裸 IP 替换成 example 的描述，现在可以一并删除。