### PR TITLE
build: add mips64el & i386 OpenWrt toolchain definitions

### DIFF
--- a/src/build/toolchain/linux/BUILD.gn
+++ b/src/build/toolchain/linux/BUILD.gn
@@ -95,6 +95,18 @@ clang_toolchain("clang_x86") {
   }
 }
 
+clang_toolchain("clang_x86_openwrt") {
+  # Output linker map files for binary size analysis.
+  enable_linker_map = true
+  extra_cppflags = "--target=i386-openwrt-linux-musl -D_LIBCPP_HAS_MUSL_LIBC -D__UCLIBC__"
+  extra_ldflags = "--target=i386-openwrt-linux-musl"
+
+  toolchain_args = {
+    current_cpu = "x86"
+    current_os = "linux"
+  }
+}
+
 clang_toolchain("clang_x86_v8_arm") {
   toolchain_args = {
     current_cpu = "x86"
@@ -221,6 +233,16 @@ clang_toolchain("clang_mipsel_openwrt") {
 }
 
 clang_toolchain("clang_mips64el") {
+  toolchain_args = {
+    current_cpu = "mips64el"
+    current_os = "linux"
+  }
+}
+
+clang_toolchain("clang_mips64el_openwrt") {
+  extra_cppflags = "--target=mips64el-openwrt-linux-musl -D_LIBCPP_HAS_MUSL_LIBC -D__UCLIBC__"
+  extra_ldflags = "--target=mips64el-openwrt-linux-musl"
+
   toolchain_args = {
     current_cpu = "mips64el"
     current_os = "linux"


### PR DESCRIPTION
OpenWrt has arch mips64el and i386, add here to support them.

Signed-off-by: CN_SZTL <cnsztl@project-openwrt.eu.org>

Ref: project-openwrt/openwrt-naiveproxy#4