### PR TITLE
Remind the go version to build server

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Users should always use the latest version to keep signatures identical to Chrom
 
 ## Server setup
 
-The following describes the naïve fork of forwardproxy setup.
+The following describes the naïve fork of forwardproxy setup. **(Golang version < 1.18)**  
 
 Build:
 ```sh


### PR DESCRIPTION
/root/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.23.0/internal/qtls/go118.go:5:13: cannot use "quic-go doesn't build on Go 1.18 yet." (untyped string constant) as int value in variable declaration  

For example: https://github.com/klzgrad/naiveproxy/issues/280