### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ route {
     hide_via
     probe_resistance
   }
-  file_server { root /var/www/html }
+  root * /var/www/html
+  file_server
 }
 ```
 `:443` must appear first for this Caddyfile to work. For more advanced usage consider using [JSON for Caddy 2's config](https://caddyserver.com/docs/json/).


### PR DESCRIPTION
file_server { /var/www/html } does not compatible with the latest caddy build. Change it to avoid misleading newbie.

```
$ ./caddy run
2022/08/10 14:37:48.503	INFO	using adjacent Caddyfile
run: adapting config using caddyfile: Caddyfile:11 - Error during parsing: Unexpected next token after '{' on same line
```
