### PR TITLE
README:delete email

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Example Caddyfile (replace `user` and `pass` accordingly):
   }
 }
 :443, example.com
-tls me@example.com
 route {
   forward_proxy {
     basic_auth user pass


### PR DESCRIPTION
TLS邮箱不是必须配置，也不必是域名后缀邮箱。