### PR TITLE
support build with windows

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -115,6 +115,6 @@ mkdir -p out
 
 export DEPOT_TOOLS_WIN_TOOLCHAIN=0
 
-./gn/out/gn gen "$out" --args="$flags $EXTRA_FLAGS" --script-executable=$PYTHON
+./gn/out/gn gen "$out" --args="$flags $EXTRA_FLAGS" --script-executable="$PYTHON"
 
 ninja -C "$out" naive

--- a/src/get-clang.sh
+++ b/src/get-clang.sh
@@ -23,7 +23,7 @@ if [ "$host_os" = mac -a "$host_cpu" = arm64 ]; then
 fi
 mkdir -p third_party/llvm-build/Release+Asserts
 cd tools/clang/scripts
-CLANG_REVISION=$($PYTHON -c 'import update; print(update.PACKAGE_VERSION)')
+CLANG_REVISION=$("$PYTHON" -c 'import update; print(update.PACKAGE_VERSION)')
 cd -
 echo $CLANG_REVISION >third_party/llvm-build/Release+Asserts/cr_build_revision
 if [ ! -d third_party/llvm-build/Release+Asserts/bin ]; then

--- a/src/get-sysroot.sh
+++ b/src/get-sysroot.sh
@@ -24,7 +24,7 @@ if [ ! "$target_cpu" ]; then
   target_cpu="$host_cpu"
 fi
 
-PYTHON=$(which python3 2>/dev/null || which python 2>/dev/null)
+PYTHON="$(which python3 2>/dev/null || which python 2>/dev/null)"
 
 # sysroot
 case "$target_os" in

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -3,6 +3,7 @@
 set -ex
 
 script_dir=$(dirname "$PWD/$0")
+PYTHON="$(which python3 2>/dev/null || which python 2>/dev/null)"
 
 [ "$1" ] || exit 1
 naive="$PWD/$1"
@@ -16,5 +17,5 @@ elif [ "$WITH_SYSROOT" ]; then
 fi
 
 cd /tmp
-python3 "$script_dir"/basic.py --naive="$naive" --rootfs="$rootfs" --target_cpu="$target_cpu" --server_protocol=https
-python3 "$script_dir"/basic.py --naive="$naive" --rootfs="$rootfs" --target_cpu="$target_cpu" --server_protocol=http
+"$PYTHON" "$script_dir"/basic.py --naive="$naive" --rootfs="$rootfs" --target_cpu="$target_cpu" --server_protocol=https
+"$PYTHON" "$script_dir"/basic.py --naive="$naive" --rootfs="$rootfs" --target_cpu="$target_cpu" --server_protocol=http


### PR DESCRIPTION
Under windows, official python installation path contains space such as "/c/Program Files/Python311/python".

Need escape PYTHON environment variable with quotes in bash script.