### PR TITLE
naive: support loong64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x64, x86, arm64, arm, mipsel, mips64el, riscv64]
+        arch: [x64, x86, arm64, arm, mipsel, mips64el, riscv64, loong64]
     env:
       EXTRA_FLAGS: 'target_cpu="${{ matrix.arch }}"'
       BUNDLE: naiveproxy-${{ github.event.release.tag_name }}-${{ github.job }}-${{ matrix.arch }}

--- a/src/base/system/sys_info.cc
+++ b/src/base/system/sys_info.cc
@@ -257,6 +257,8 @@ std::string SysInfo::ProcessCPUArchitecture() {
   return "ARM_64";
 #elif defined(ARCH_CPU_RISCV64)
   return "RISCV_64";
+#elif defined(ARCH_CPU_LOONGARCH64)
+  return "LOONGARCH_64";
 #else
   return std::string();
 #endif

--- a/src/build.sh
+++ b/src/build.sh
@@ -71,7 +71,10 @@ flags="$flags"'
   enable_dangling_raw_ptr_checks=false
 '
 
-if [ "$WITH_SYSROOT" ]; then
+if [ "$SYSROOT_ARCH" = "loong64" -a "$WITH_SYSROOT" ]; then
+  flags="$flags
+    target_sysroot=\"//$WITH_SYSROOT/target\""
+elif [ "$WITH_SYSROOT" ]; then
   flags="$flags
     target_sysroot=\"//$WITH_SYSROOT\""
 fi

--- a/src/build/config/compiler/BUILD.gn
+++ b/src/build/config/compiler/BUILD.gn
@@ -309,6 +309,10 @@ config("compiler") {
     if (current_os == "openwrt") {
       configs += [ "//build/config/openwrt:compiler" ]
     }
+    if (current_cpu == "loong64") {
+      # fix this hardcode
+      ldflags += [ "--gcc-install-dir=../sysroot-build/bullseye/bullseye_loong64_staging/lib/gcc/loongarch64-unknown-linux-gnu/13.2.0"]
+    }
   } else if (is_nacl) {
     configs += [ "//build/config/nacl:compiler" ]
   } else if (is_mac) {

--- a/src/build/config/linux/pkg-config.py
+++ b/src/build/config/linux/pkg-config.py
@@ -59,6 +59,8 @@ def SetConfigPath(options):
     sys.exit(1)
 
   libdir = sysroot + '/usr/' + options.system_libdir + '/pkgconfig'
+  if arch == 'loong64':
+    libdir += ':' + sysroot + '/usr/' + 'lib64' + '/pkgconfig'
   libdir += ':' + sysroot + '/usr/share/pkgconfig'
   os.environ['PKG_CONFIG_LIBDIR'] = libdir
   return libdir

--- a/src/build/config/sysroot.gni
+++ b/src/build/config/sysroot.gni
@@ -22,7 +22,8 @@ declare_args() {
   use_sysroot =
       current_cpu == "x86" || current_cpu == "x64" || current_cpu == "arm" ||
       current_cpu == "arm64" || current_cpu == "mipsel" ||
-      current_cpu == "mips64el" || (current_cpu == "riscv64" && is_android)
+      current_cpu == "mips64el" || (current_cpu == "riscv64" && is_android) ||
+      current_cpu == "loong64"
 }
 
 if (sysroot == "") {
@@ -49,6 +50,8 @@ if (sysroot == "") {
       sysroot = "$target_sysroot_dir/debian_bullseye_armhf-sysroot"
     } else if (current_cpu == "arm64") {
       sysroot = "$target_sysroot_dir/debian_bullseye_arm64-sysroot"
+    } else if (current_cpu == "loong64") {
+      sysroot = "$target_sysroot_dir/debian_bullseye_loong64-sysroot/target"
     } else {
       assert(false, "No linux sysroot for cpu: $target_cpu")
     }

--- a/src/build/linux/sysroot_scripts/install-sysroot.py
+++ b/src/build/linux/sysroot_scripts/install-sysroot.py
@@ -35,7 +35,7 @@ from urllib.request import urlopen
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 SRC_DIR = os.path.dirname(os.path.dirname(os.path.dirname(SCRIPT_DIR)))
 
-VALID_ARCHS = ('amd64', 'i386', 'armhf', 'arm64', 'armel', 'mipsel', 'mips64el', 'riscv64')
+VALID_ARCHS = ('amd64', 'i386', 'armhf', 'arm64', 'armel', 'mipsel', 'mips64el', 'riscv64', 'loong64')
 
 ARCH_TRANSLATIONS = {
     'x64': 'amd64',

--- a/src/build/linux/sysroot_scripts/sysroots.json
+++ b/src/build/linux/sysroot_scripts/sysroots.json
@@ -53,5 +53,11 @@
         "Sha1Sum": "",
         "SysrootDir": "debian_bullseye_riscv64-sysroot",
         "Tarball": "debian_bullseye_riscv64_sysroot.tar.xz"
+    },
+    "bullseye_loong64": {
+        "Key": "",
+        "Sha1Sum": "",
+        "SysrootDir": "debian_bullseye_loong64-sysroot",
+        "Tarball": "debian_bullseye_loong64_sysroot.tar.xz"
     }
 }

--- a/src/get-clang.sh
+++ b/src/get-clang.sh
@@ -3,7 +3,16 @@ set -ex
 
 . ./get-sysroot.sh
 
-if [ "$SYSROOT_ARCH" -a ! -d ./"$WITH_SYSROOT/lib" ]; then
+if [ "$SYSROOT_ARCH" = "loong64" -a ! -d ./"$WITH_SYSROOT/target" ]; then
+mkdir -p "$WITH_SYSROOT"
+pushd "$WITH_SYSROOT"
+curl -L https://github.com/loongson/build-tools/releases/download/2023.08.08/CLFS-loongarch64-8.1-x86_64-cross-tools-gcc-glibc.tar.xz | tar --strip-components=1 --xz -xf -
+cp -fv ./loongarch64-unknown-linux-gnu/lib/libatomic.so target/lib64/
+cp -fv ./loongarch64-unknown-linux-gnu/lib/libgcc_s.so target/lib64/
+cp -fv ./loongarch64-unknown-linux-gnu/lib/libgcc_s.so.1 target/lib64/
+rm -rf bin include libexec loongarch64-unknown-linux-gnu share
+popd
+elif [ "$SYSROOT_ARCH" -a ! -d ./"$WITH_SYSROOT/lib" ]; then
   ./build/linux/sysroot_scripts/sysroot_creator.py build "$SYSROOT_ARCH"
 fi
 

--- a/src/get-sysroot.sh
+++ b/src/get-sysroot.sh
@@ -37,6 +37,7 @@ case "$target_os" in
       mipsel) SYSROOT_ARCH=mipsel;;
       mips64el) SYSROOT_ARCH=mips64el;;
       riscv64) SYSROOT_ARCH=riscv64;;
+      loong64) SYSROOT_ARCH=loong64;;
     esac
     if [ "$SYSROOT_ARCH" ]; then
       WITH_SYSROOT="out/sysroot-build/bullseye/bullseye_${SYSROOT_ARCH}_staging"

--- a/src/third_party/boringssl/src/include/openssl/target.h
+++ b/src/third_party/boringssl/src/include/openssl/target.h
@@ -45,6 +45,12 @@
 #define OPENSSL_RISCV64
 #elif defined(__riscv) && __SIZEOF_POINTER__ == 4
 #define OPENSSL_32_BIT
+#elif defined(__loongarch__) && !defined(__loongarch_lp64)
+#define OPENSSL_32_BIT
+#define OPENSSL_LOONGARCH
+#elif defined(__loongarch__) && defined(__loongarch_lp64)
+#define OPENSSL_64_BIT
+#define OPENSSL_LOONGARCH64
 #elif defined(__pnacl__)
 #define OPENSSL_32_BIT
 #define OPENSSL_PNACL

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -78,6 +78,8 @@ def start_naive(naive_args, config_file):
         with_qemu = 'mips64el'
     elif argv.target_cpu == 'riscv64':
         with_qemu = 'riscv64'
+    elif argv.target_cpu == 'loong64':
+        with_qemu = 'loongarch64'
 
     if argv.rootfs:
         if not with_qemu:

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -11,6 +11,8 @@ naive="$PWD/$1"
 
 if [ "$WITH_ANDROID_IMG" ]; then
   rootfs="$PWD/out/sysroot-build/android/$WITH_ANDROID_IMG"
+elif [ "$SYSROOT_ARCH" = "loong64" -a "$WITH_SYSROOT" ]; then
+  rootfs="$PWD/$WITH_SYSROOT/target"
 elif [ "$WITH_SYSROOT" ]; then
   rootfs="$PWD/$WITH_SYSROOT"
 fi


### PR DESCRIPTION
tested with ../tests/basic.sh out/Release/naive.

base changes come from chromium loong's official patch: https://github.com/loongson/chromium/blob/loongarch-patches/chromium120/new-world/0001-CH120-new-world-Add-llvm-cross-build-support-for-loo.patch

Using the tarball from https://github.com/loongson/build-tools/releases instead of debian (which just accept loongarch64 as its port) and the debian sysroot support might be very new https://wiki.debian.org/Ports/loong64 (I didn't have a change to see it).