### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/src/third_party/nasm/asm/parser.c
+++ b/src/third_party/nasm/asm/parser.c
@@ -458,11 +458,17 @@ static int parse_eops(extop **result, bool critical, int elem)
                 /* Subexpression is empty */
                 eop->type = EOT_NOTHING;
             } else if (!subexpr->next) {
-                /* Subexpression is a single element, flatten */
-                eop->val   = subexpr->val;
-                eop->type  = subexpr->type;
-                eop->dup  *= subexpr->dup;
-                nasm_free(subexpr);
+                /*
+                 * Subexpression is a single element, flatten.
+                 * Note that if subexpr has an allocated buffer associated
+                 * with it, freeing it would free the buffer, too, so
+                 * we need to move subexpr up, not eop down.
+                 */
+                if (!subexpr->elem)
+                    subexpr->elem = eop->elem;
+                subexpr->dup *= eop->dup;
+                nasm_free(eop);
+                eop = subexpr;
             } else {
                 eop->type = EOT_EXTOP;
             }


### PR DESCRIPTION
Fix: Potential Vulnerability in Cloned Function

**Description**
This PR fixes a security vulnerability in parse_eops() that was cloned from nasm but did not receive the security patch. The original issue was reported and fixed under https://github.com/netwide-assembler/nasm/commit/6ac6ac57e3d01ea8ed4ea47706eb724b59176461.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2020-24241
https://github.com/netwide-assembler/nasm/commit/6ac6ac57e3d01ea8ed4ea47706eb724b59176461
