### PR TITLE
Fix QUIC proxy Fast Open DCHECK

### DIFF
--- a/src/net/quic/quic_proxy_client_socket.cc
+++ b/src/net/quic/quic_proxy_client_socket.cc
@@ -281,9 +281,19 @@ void QuicProxyClientSocket::OnIOComplete(int result) {
   DCHECK_NE(STATE_DISCONNECTED, next_state_);
   int rv = DoLoop(result);
   if (rv != ERR_IO_PENDING) {
-    // Connect() finished (successfully or unsuccessfully).
-    DCHECK(!connect_callback_.is_null());
-    std::move(connect_callback_).Run(rv);
+    if (!connect_callback_.is_null()) {
+      // Connect() finished (successfully or unsuccessfully).
+      std::move(connect_callback_).Run(rv);
+      return;
+    }
+
+    DCHECK(use_fastopen_);
+    read_headers_pending_ = false;
+    next_state_ = STATE_DISCONNECTED;
+    if (!read_callback_.is_null()) {
+      read_buf_ = nullptr;
+      std::move(read_callback_).Run(rv);
+    }
   }
 }
 
@@ -340,12 +350,17 @@ int QuicProxyClientSocket::DoLoop(int last_io_result) {
         if (use_fastopen_ && read_headers_pending_) {
           read_headers_pending_ = false;
           if (rv < 0) {
-            // read_callback_ will be called with this error and be reset.
-            // Further data after that will be ignored.
+            // If a Read() is pending, OnIOComplete() will report this error to
+            // that callback. Otherwise keep the completed Connect() quiet and
+            // leave the socket disconnected for any future operations.
             next_state_ = STATE_DISCONNECTED;
+            if (read_callback_.is_null())
+              rv = ERR_IO_PENDING;
+          } else {
+            // Prevents calling connect_callback_ after Fast Open Connect()
+            // already completed synchronously.
+            rv = ERR_IO_PENDING;
           }
-          // Prevents calling connect_callback_.
-          rv = ERR_IO_PENDING;
         }
         break;
       default:


### PR DESCRIPTION
## Summary

Fix a debug-mode DCHECK crash in `QuicProxyClientSocket` when QUIC proxy Fast Open completes `Connect()` before response headers are received, then the pending header read fails later.

## Crashing thread

```txt
#0  libc abort path
#1  raise
#2  abort
#3  logging::LogMessage::HandleFatal
#4  logging::LogMessage::Flush
#5  logging::CheckError::~CheckError
#6  net::QuicProxyClientSocket::OnIOComplete(int)
#7  net::QuicProxyClientSocket::OnReadResponseHeadersComplete(int)
#8  base::OnceCallback<void(int)>::Run(int)
#9  net::QuicChromiumClientStream::Handle::ResetAndRun(base::OnceCallback<void(int)>, int)
#10 net::QuicChromiumClientStream::Handle::InvokeCallbacksOnClose(int)
#11 base::OnceCallback<void()>::Run()
#12 base::TaskAnnotator::RunTaskImpl(base::PendingTask&)
#13 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(...)
#14 base::MessagePumpEpoll::Run(...)
#15 base::RunLoop::Run(...)
#16 main
```

Final failure:

```txt
net/quic/quic_proxy_client_socket.cc:285
DCHECK(!connect_callback_.is_null())
```

Observed state at the crash:

```txt
result = -356  // ERR_QUIC_PROTOCOL_ERROR
use_fastopen_ = true
read_headers_pending_ = true
connect_callback_ = null
read_callback_ = non-null
endpoint = accounts.google.com:443
```

## Root cause

In the QUIC Fast Open path, `DoReadReply()` may start `ReadInitialHeaders()` asynchronously, set `read_headers_pending_ = true`, move the socket to `STATE_CONNECT_COMPLETE`, and return `OK`.

That completes `Connect()`, so `connect_callback_` is no longer owned by the socket.

If the pending response-header operation later fails, `OnReadResponseHeadersComplete()` calls back into `OnIOComplete()`. Before this patch, `OnIOComplete()` unconditionally treated any non-pending result as connect completion and DCHECKed that `connect_callback_` existed. In Fast Open, that assumption is false: the failure belongs to the already-open tunnel/read side, not to `Connect()`.

## Fix

Handle the post-Connect Fast Open completion path explicitly:

- If `OnIOComplete()` still has `connect_callback_`, keep the original connect-completion behavior.
- Otherwise, require the path to be Fast Open, clear pending header state, disconnect the socket, and report the error to the pending read callback when one exists.
- In `STATE_PROCESS_RESPONSE_CODE`, avoid issuing a second connect completion after Fast Open already completed; response-code failures either flow to the pending read callback or leave the socket disconnected if no read is pending.

This fixes the state-machine ownership bug instead of bypassing the DCHECK: a completed `Connect()` remains one-shot, read-side failures are delivered to read-side callbacks, and future operations see a disconnected socket after failure.

## Verification

```sh
ninja -C src/out/Debug naive
../tests/basic.sh out/Debug/naive
```

Also verified that new compiled binary with this fix are working fine in various manual testing.

## Disclaimer

This pull request is assisted by GPT-5.5
