### PR TITLE
docs: explain why `:443` (not `example.com:443`) is required for forward_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,27 @@ Example Caddyfile (replace `user` and `pass` accordingly):
   }
 }
 ```
-`:443` must appear first for this Caddyfile to work. See Caddyfile [docs](https://caddyserver.com/docs/caddyfile/directives/tls) for customizing TLS certificates. For more advanced usage consider using [JSON for Caddy 2's config](https://caddyserver.com/docs/json/).
+`:443` must appear first for this Caddyfile to work.
+
+> **Warning: do not use `example.com:443` (a hostname) as the site address.**
+>
+> When a hostname (e.g. `example.com:443` or `example.com`) is used as the site
+> address, Caddy inserts an implicit **host matcher** that only accepts requests
+> whose `Host` header / TLS SNI matches that hostname. However, when a client
+> uses NaiveProxy as a forward proxy, the HTTP `CONNECT` request it sends carries
+> the **target site's** hostname (e.g. `www.google.com:443`), not your proxy
+> server's hostname. The host matcher then rejects the `CONNECT` request before
+> it ever reaches `forward_proxy`, so the client receives `200 OK` with
+> `Content-Length: 0` (or the connection is closed immediately) and no traffic
+> flows. The naive client logs `negotiated padding type: None` (see #639).
+>
+> Using `:443` (no hostname) removes the host matcher, so all `CONNECT` requests
+> reach `forward_proxy` and are authenticated/handled correctly. If you need
+> multiple hostnames on the same port, put `:443` first and use separate
+> `forward_proxy` blocks (the host matcher approach does not work with
+> `forward_proxy`, see #639, #809).
+
+See Caddyfile [docs](https://caddyserver.com/docs/caddyfile/directives/tls) for customizing TLS certificates. For more advanced usage consider using [JSON for Caddy 2's config](https://caddyserver.com/docs/json/).
 
 Run with the Caddyfile:
 ```


### PR DESCRIPTION
## What

Expands the existing half-sentence warning (\"`:443` must appear first\") into a full explanation of **why** a hostname must not be used as the site address when `forward_proxy` is enabled.

## Why

This is a very common footgun. Users copy the example and write `example.com:443` or `my-domain.com:443`, then hit one of these symptoms:

- naive client logs `negotiated padding type: None` + `Connection closed: ERR_SOCKET_NOT_CONNECTED`
- `curl -x https://user:pass@host:443 ...` returns `200 OK` with `Content-Length: 0`, no traffic flows
- probe returns the frontend site; the proxy \"works\" but tunnels nothing

## Root cause

A hostname in the site address inserts a Caddy **host matcher**. A forward-proxy `CONNECT` request carries the *target* host (e.g. `www.google.com`), not the proxy server's host, so the matcher rejects it before `forward_proxy` runs. Using `:443` (no hostname) removes the matcher.

## Evidence (reproduced locally)

With `domain:443` as the site address:
- Caddy debug log shows the `CONNECT` request handled as `NOP`
- `forward_proxy` is never invoked (no `Padding` response header in the `CONNECT` response)
- naive client: `negotiated padding type: None` → `ERR_SOCKET_NOT_CONNECTED`

With `:443`:
- Same `CONNECT` reaches `forward_proxy`, response includes the `Padding` header
- `negotiated padding type: Variant1`, tunneling works

## Related

- #639 — klzgrad: *\"padding type: None means your server isn't configured correctly\"*; the `match` block finding there is the JSON-config form of the same root cause.
- #809 — multi-site variant of the same host-matcher issue.

## Scope

Docs-only change to `README.md`. No code changes.