### PR TITLE
Fix insufficient resources error handling

### DIFF
--- a/src/net/tools/naive/naive_proxy.cc
+++ b/src/net/tools/naive/naive_proxy.cc
@@ -145,7 +145,14 @@ int NaiveProxy::DoAcceptComplete(int result) {
   if (result != OK) {
     next_state_ = State::kAccept;
     LOG(ERROR) << "Accept error: " << ErrorToShortString(result);
-    // This accept error is ignored to start the next accept.
+    if (result == ERR_INSUFFICIENT_RESOURCES) {
+      base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
+          FROM_HERE,
+          base::BindOnce(&NaiveProxy::OnIOComplete,
+                         weak_ptr_factory_.GetWeakPtr(), OK),
+          base::Seconds(1));
+      return ERR_IO_PENDING;
+    }
     return OK;
   }
 


### PR DESCRIPTION
When naive DoAccept failed on ERR_INSUFFICIENT_RESOURCES, rv is passed to DoAcceptComplete, if rv is not OK, this function sets next state to DoAccept again, when naive reaches system wide file discriptor limits, and a pending CONNECT in queue, naive will be trapped in an infinite busy spinning loop and can not recover as resources are not reclaimed.

Trigger requirements:

1. Naive has reached its per-process file descriptor limit or the system-wide descriptor limit.
2. A new TCP connection is waiting in the listening socket’s accept queue

The patch schedules a 1 second retry, and returns ERR_IO_PENDING to exit DoLoop from busy spinning, and calls OnIOComplete to reclaim resources, so naive can recover from this trap.

This issue is founded when testing naive with #818 , DNS on UDP can consume resources very quickly, and would trigger this issue. Though on CONNECT (TCP) this case is very rare it could happen.