### PR TITLE
net/quic: wake buffered body reads after initial headers

### DIFF
--- a/src/net/quic/quic_chromium_client_stream.cc
+++ b/src/net/quic/quic_chromium_client_stream.cc
@@ -869,6 +869,14 @@ int QuicChromiumClientStream::DeliverInitialHeaders(
     return ERR_INVALID_RESPONSE;
   }
 
+  // Body data can arrive before the initial headers are delivered to the
+  // handle (notably when the proxy socket uses Fast Open). OnBodyAvailable()
+  // intentionally buffers that notification while headers_delivered_ is
+  // false. Re-check the stream now that the headers are visible so a pending
+  // ReadBody() is woken up instead of waiting indefinitely.
+  if (handle_ && (HasBytesToRead() || FinishedReadingTrailers()))
+    NotifyHandleOfDataAvailableLater();
+
   net_log_.AddEvent(
       NetLogEventType::QUIC_CHROMIUM_CLIENT_STREAM_READ_RESPONSE_HEADERS,
       [&](NetLogCaptureMode capture_mode) {

--- a/src/net/quic/quic_chromium_client_stream.cc
+++ b/src/net/quic/quic_chromium_client_stream.cc
@@ -869,14 +869,10 @@ int QuicChromiumClientStream::DeliverInitialHeaders(
     return ERR_INVALID_RESPONSE;
   }
 
-  // During proxy Fast Open, HEADERS and DATA may be received back to back.
-  // OnInitialHeadersComplete() posts DeliverInitialHeaders(), which returns to
-  // QuicHttpStream::OnReadResponseHeadersComplete(). That task may run after
-  // OnBodyAvailable() processes the DATA frame, so the latter sees that
-  // initial headers have not been delivered and does not post
-  // OnDataAvailable(). Re-check after delivering the initial headers so a
-  // pending ReadBody() is woken when body data or completed trailers are
-  // already buffered.
+  // During proxy Fast Open, DeliverInitialHeaders() queued from
+  // OnInitialHeadersComplete() can be delayed after OnBodyAvailable(),
+  // which then skips calling OnDataAvailable() and stalls ReadBody().
+  // Resumes OnDataAvailable() from here as if from OnBodyAvailable().
   if (handle_ && (HasBytesToRead() || FinishedReadingTrailers()))
     NotifyHandleOfDataAvailableLater();
 

--- a/src/net/quic/quic_chromium_client_stream.cc
+++ b/src/net/quic/quic_chromium_client_stream.cc
@@ -869,11 +869,14 @@ int QuicChromiumClientStream::DeliverInitialHeaders(
     return ERR_INVALID_RESPONSE;
   }
 
-  // Body data can arrive before the initial headers are delivered to the
-  // handle (notably when the proxy socket uses Fast Open). OnBodyAvailable()
-  // intentionally buffers that notification while headers_delivered_ is
-  // false. Re-check the stream now that the headers are visible so a pending
-  // ReadBody() is woken up instead of waiting indefinitely.
+  // During proxy Fast Open, HEADERS and DATA may be received back to back.
+  // OnInitialHeadersComplete() posts DeliverInitialHeaders(), which returns to
+  // QuicHttpStream::OnReadResponseHeadersComplete(). That task may run after
+  // OnBodyAvailable() processes the DATA frame, so the latter sees that
+  // initial headers have not been delivered and does not post
+  // OnDataAvailable(). Re-check after delivering the initial headers so a
+  // pending ReadBody() is woken when body data or completed trailers are
+  // already buffered.
   if (handle_ && (HasBytesToRead() || FinishedReadingTrailers()))
     NotifyHandleOfDataAvailableLater();
 


### PR DESCRIPTION
A QUIC proxy tunnel using Fast Open can leave an application body read pending even after response data is available. `OnBodyAvailable()` defers notification while `headers_delivered_` is false; delivering the initial headers does not recheck that buffered data. If no further data notification arrives, the read stalls.

After successful initial-header delivery, schedule the existing asynchronous data notification when readable bytes or the completed trailers/FIN state are present. The posted notification uses the existing weak-pointer path, so header completion runs before the body callback.

Validation: the previous client timed out on one of eight identical download attempts; the client containing this fix completed all eight. Subsequent validation of the fixed client passed all 56 HTTP/HTTPS TCP regression cases.
