### PR TITLE
net/spdy: propagate invalid CONNECT response headers

### DIFF
--- a/src/net/spdy/spdy_proxy_client_socket.cc
+++ b/src/net/spdy/spdy_proxy_client_socket.cc
@@ -322,9 +322,11 @@ void SpdyProxyClientSocket::OnIOComplete(int result) {
   int rv = DoLoop(result);
   if (rv != ERR_IO_PENDING) {
     if (use_fastopen_ && read_headers_pending_ == false) {
-      if (rv < 0)
+      if (rv != OK)
         next_state_ = STATE_DISCONNECTED;
-      if (!read_callback_ || rv == OK) return;
+      if (read_callback_ && rv != OK)
+        std::move(read_callback_).Run(rv);
+      return;
     }
     std::move(read_callback_).Run(rv);
   }

--- a/src/net/spdy/spdy_proxy_client_socket.cc
+++ b/src/net/spdy/spdy_proxy_client_socket.cc
@@ -321,6 +321,11 @@ void SpdyProxyClientSocket::OnIOComplete(int result) {
   DCHECK_NE(STATE_DISCONNECTED, next_state_);
   int rv = DoLoop(result);
   if (rv != ERR_IO_PENDING) {
+    if (use_fastopen_ && read_headers_pending_ == false) {
+      if (rv < 0)
+        next_state_ = STATE_DISCONNECTED;
+      if (!read_callback_ || rv == OK) return;
+    }
     std::move(read_callback_).Run(rv);
   }
 }
@@ -394,20 +399,6 @@ int SpdyProxyClientSocket::DoLoop(int last_io_result) {
       case STATE_PROCESS_RESPONSE_CODE:
         DCHECK_EQ(OK, rv);
         rv = DoProcessResponseCode();
-        if (use_fastopen_ && read_headers_pending_) {
-          read_headers_pending_ = false;
-          if (rv < 0) {
-            // read_callback_ cannot be called.
-            if (!read_callback_)
-              rv = ERR_IO_PENDING;
-            // read_callback_ will be called with this error and be reset.
-            // Further data after that will be ignored.
-            next_state_ = STATE_DISCONNECTED;
-          } else {
-            // Does not call read_callback_ from here if headers are OK.
-            rv = ERR_IO_PENDING;
-          }
-        }
         break;
       default:
         NOTREACHED() << "bad state";
@@ -554,12 +545,6 @@ int SpdyProxyClientSocket::DoReadReplyComplete(int result) {
   if (result < 0)
     return result;
 
-  // SpdyHeadersToHttpResponse() may have failed to convert the response
-  // headers (e.g. duplicate location values), in which case
-  // response_.headers is null and must not be dereferenced.
-  if (!response_.headers)
-    return ERR_TUNNEL_CONNECTION_FAILED;
-
   // Require the "HTTP/1.x" status line for SSL CONNECT.
   if (response_.headers->GetHttpVersion() < HttpVersion(1, 0))
     return ERR_TUNNEL_CONNECTION_FAILED;
@@ -639,6 +624,7 @@ void SpdyProxyClientSocket::OnEarlyHintsReceived(
 void SpdyProxyClientSocket::OnHeadersReceived(
     const quiche::HttpHeaderBlock& response_headers) {
   if (use_fastopen_ && read_headers_pending_ && next_state_ == STATE_OPEN) {
+    read_headers_pending_ = false;
     next_state_ = STATE_READ_REPLY_COMPLETE;
   }
 
@@ -652,7 +638,7 @@ void SpdyProxyClientSocket::OnHeadersReceived(
   const int rv = SpdyHeadersToHttpResponse(response_headers, &response_);
   DCHECK_NE(rv, ERR_INCOMPLETE_HTTP2_HEADERS);
 
-  OnIOComplete(OK);
+  OnIOComplete(rv);
 }
 
 // Called when data is received or on EOF (if `buffer is nullptr).

--- a/src/net/spdy/spdy_proxy_client_socket.cc
+++ b/src/net/spdy/spdy_proxy_client_socket.cc
@@ -554,6 +554,12 @@ int SpdyProxyClientSocket::DoReadReplyComplete(int result) {
   if (result < 0)
     return result;
 
+  // SpdyHeadersToHttpResponse() may have failed to convert the response
+  // headers (e.g. duplicate location values), in which case
+  // response_.headers is null and must not be dereferenced.
+  if (!response_.headers)
+    return ERR_TUNNEL_CONNECTION_FAILED;
+
   // Require the "HTTP/1.x" status line for SSL CONNECT.
   if (response_.headers->GetHttpVersion() < HttpVersion(1, 0))
     return ERR_TUNNEL_CONNECTION_FAILED;

--- a/src/net/spdy/spdy_proxy_client_socket.h
+++ b/src/net/spdy/spdy_proxy_client_socket.h
@@ -202,7 +202,7 @@ class NET_EXPORT_PRIVATE SpdyProxyClientSocket : public ProxyClientSocket,
 
   bool use_fastopen_ = false;
   std::optional<size_t> preamble_index_;
-  bool read_headers_pending_ = false;
+  std::optional<bool> read_headers_pending_;
 
   const NetLogWithSource net_log_;
   const NetLogSource source_dependency_;


### PR DESCRIPTION
`SpdyProxyClientSocket::OnHeadersReceived()` ignores the result of `SpdyHeadersToHttpResponse()` and always calls `OnIOComplete(OK)`. On conversion failure, `response_.headers` stays null, and `DoReadReplyComplete()` then dereferences it unconditionally (`response_.headers->GetHttpVersion()`).

A concrete conversion-error path is two different `location` values: both conversion implementations return `ERR_RESPONSE_HEADERS_MULTIPLE_LOCATION` before assigning `response_.headers`. A missing `:status` is not needed to reach this conversion error; that case is already rejected earlier by `SpdyStream`.

Propagate the conversion result to `OnIOComplete()` so the existing `if (result < 0) return result;` short-circuit in `DoReadReplyComplete()` fails with the actual conversion error before the dereference. This covers both the normal CONNECT path and the Fast Open path: in the latter, `Connect()` has already completed early, so `OnIOComplete()` completes a pending application read with the error and transitions to `STATE_DISCONNECTED` on failure. `read_headers_pending_` becomes `std::optional<bool>` and is cleared when the response headers are processed, so it cannot dangle on the conversion-failure path.

Validation: the client containing this fix passed all 56 HTTP/HTTPS TCP regression cases (28 per protocol, `tests/basic.py`). The duplicate-location trigger was established by source inspection of both `SpdyHeadersToHttpResponse` implementations.
